### PR TITLE
Strip leading slash in template name

### DIFF
--- a/tasks/emblem.js
+++ b/tasks/emblem.js
@@ -143,7 +143,7 @@ module.exports = function(grunt) {
       key = JSON.stringify(this.keyForFilePath(filepath));
       compiled = this.window.Emblem.precompile(this.window.Ember.Handlebars, src);
       template = "Ember.Handlebars.template(" + compiled + ")";
-      return "Ember.TEMPLATES[" + key + "] = " + template + ";";
+      return "Ember.TEMPLATES[" + key.replace(/^"\//, '"') + "] = " + template + ";";
     };
 
     return EmberBuilder;


### PR DESCRIPTION
I couldn't get Ember to find the templates unless I used this patch. Basically, without the patch, I get something like:

```
Ember.TEMPLATES["/application"] = Ember.Handlebars.template(function ...
```

That leading slash in `"/application"` is causing the problem. This patch removes it to yield:

```
Ember.TEMPLATES["application"] = Ember.Handlebars.template(function ...
```
