### PR TITLE
Add AMD support

### DIFF
--- a/tasks/emblem.js
+++ b/tasks/emblem.js
@@ -74,6 +74,12 @@ module.exports = function(grunt) {
       if (templates.length < 1) {
         grunt.log.warn("Destination not written because compiled files were empty.");
       } else {
+
+        if (options.amd) {
+          templates.unshift('define(["ember"], function(Ember){');
+          templates.push('});');
+        }
+
         writeOutput(templates, f, options.separator);
       }
     });


### PR DESCRIPTION
I wasn't able to test, since I'm getting the following warning on `grunt test`, even on a fresh repo, and I'm not sure how to resolve it:

``` bash
Running "clean:test" (clean) task
Cleaning "tmp"...OK

Running "emblem:ember" (emblem) task
File "tmp/emblem-ember.js" created.

Running "emblem:basic" (emblem) task
File "tmp/emblem-basic.js" created.

Running "simplemocha:all" (simplemocha) task
Warning: Arguments to path.resolve must be strings Use --force to continue.

Aborted due to warnings.
```

Running `npm test` doesn't give me any helpful clues either, unfortunately.
But it works for me as expected in a test run of `grunt emblem:compile` with the option `amd: true`.
